### PR TITLE
Sprint 5: Introduce Redis database

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# The password that Redis will use
+REDIS_PASSWORD=YourSuperSecretPassword123

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore persisted data directories
+data/
+redis-insight-data/
+
+# Ignore common system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# e-redis
+# Redis Docker Stack
+
+This repository contains the necessary configuration to run a Redis database and the RedisInsight GUI using Docker Compose.
+
+## How to Run
+
+1.  Clone this repository.
+2.  Create a `.env` file from the example or by copying the content from the README. Set your desired `REDIS_PASSWORD`.
+3.  Run the command: `docker-compose up -d`
+4.  You can now connect to Redis at `localhost:6379`.
+5.  Access the RedisInsight GUI by navigating to [http://localhost:5540](http://localhost:5540) in your browser.
+
+## Services
+
+* **Redis:** The database, running on port `6379`.
+* **RedisInsight:** The GUI, accessible on port `5540`.

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,0 +1,22 @@
+# --- Persistence ---
+# Enables AOF (Append Only File) persistence for better durability.
+# This helps recover data in case of a crash.
+appendonly yes
+
+# --- Memory Management ---
+# Set a memory usage limit to prevent Redis from consuming all system RAM.
+# Useful for development to avoid system instability.
+maxmemory 256mb
+
+# When the maxmemory limit is reached, Redis needs a policy to decide what to evict.
+# 'allkeys-lru' removes the least recently used keys, which is a good general-purpose choice.
+maxmemory-policy allkeys-lru
+
+# --- Slow Log ---
+# Log queries that take longer than a specified time in microseconds.
+# This is extremely useful for debugging performance bottlenecks.
+# 10000 microseconds = 10 milliseconds. Set to 0 to log every command.
+slowlog-log-slower-than 10000
+
+# The slow log is kept in memory. This sets the maximum number of items in the log.
+slowlog-max-len 128

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+# docker-compose.yml
+version: '3.8'
+
+services:
+  # The Redis Database Service
+  redis:
+    image: redis:latest
+    container_name: redis_db
+    restart: always
+    ports:
+      - "6379:6379" # Expose Redis on the default port
+    volumes:
+      - redis-data:/data
+      - ./config/redis.conf:/usr/local/etc/redis/redis.conf # Mount custom configuration
+    command: redis-server /usr/local/etc/redis/redis.conf --requirepass ${REDIS_PASSWORD}
+    networks:
+      - redis-net
+
+  # The GUI Client Service
+  redis-insight:
+    image: redis/redisinsight:latest
+    container_name: redis_gui
+    restart: always
+    ports:
+      - "5540:5540" # Expose the GUI on port 5540
+    volumes:
+      - ./redis-insight-data:/db
+    networks:
+      - redis-net
+
+networks:
+  redis-net:
+    driver: bridge
+
+volumes:
+  redis-data:
+  redis-insight-data:


### PR DESCRIPTION
1. Jira Ticket: [EJ-59](https://ecommercedev.atlassian.net/jira/software/projects/EJ/boards/2?selectedIssue=EJ-59)

2. Description
   A fast and reliable database is needed due to the requirement of saving the refresh tokens (obtained during authentication) in a way that they are fast and easy to obtain whenever they are needed.

4. Solution
   Instead of keeping the refresh tokens in the main database, a second blazing fast database will be introduced - Redis. The currnet composition offers two containers - the actual database and a GUI for accessing the database through your browser. The database is running on port `6379` and the GUI - `5540`. The `redis.config` file enforces the following:

   - Enables AOF (Append Only File) persistence for better durability.
   - Set a memory usage limit to prevent Redis from consuming all system RAM. (256MB)
   - When the maxmemory limit is reached, Redis removes the least recently used keys.
   - Logs queries that take longer than a specified time in microseconds (10ms). This is extremely useful for debugging performance bottlenecks.
   - Sets the maximum number of items in the log - 128.

5. Testing
   The database and the GUI are both tested manually and work correctly. All CRUD operations works from the console and the browser.

7. Pipeline Verification - Not available